### PR TITLE
array keys tussen quotes

### DIFF
--- a/meertens-corp-wp-theme/sidebar.php
+++ b/meertens-corp-wp-theme/sidebar.php
@@ -34,21 +34,21 @@
       $baseUrl = get_site_url();
       $transLink = '';
 
-      if ($langData[nl][current_lang] == 1) {
+      if ($langData['nl']['current_lang'] == 1) {
         // nl page
 
-        if ($langData[en][url]  != $baseUrl.'/index.php/en/') {
+        if ($langData['en']['url']  != $baseUrl.'/index.php/en/') {
           // if has translation
-          $transLink = '<a href="'.$langData[en][url].'">English</a>';
+          $transLink = '<a href="'.$langData['en']['url'].'">English</a>';
         }
         if ( is_home() ) {
           $transLink = '<a href="/index.php/en/">English</a>';
         }
       } else {
         //eng page
-        if ($langData[nl][url]  != $baseUrl) {
+        if ($langData['nl']['url']  != $baseUrl) {
           // if has translation
-          $transLink = '<a href="'.$langData[nl][url].'">Nederlands</a>';
+          $transLink = '<a href="'.$langData['nl']['url'].'">Nederlands</a>';
         }
         if ( is_home() ) {
           $transLink = '<a href="/index.php/">Nederlands</a>';


### PR DESCRIPTION
In sidebar.php: niet bv. [nl] maar ['nl'].
Strings zonder quotes leveren warnings op, en volle logfiles